### PR TITLE
Allow for optionally passing options to `#remove`

### DIFF
--- a/core/lib/testcontainers/docker_container.rb
+++ b/core/lib/testcontainers/docker_container.rb
@@ -530,11 +530,12 @@ module Testcontainers
 
     # Removes the container.
     #
+    # @param options [Hash] Additional options to send to the container remove command.
     # @return [DockerContainer] The DockerContainer instance.
     # @return [nil] If the container does not exist.
     # @raise [ConnectionError] If the connection to the Docker daemon fails.
-    def remove
-      @_container&.remove
+    def remove(options = {})
+      @_container&.remove(options)
       @_container = nil
       self
     rescue Excon::Error::Socket => e
@@ -730,6 +731,24 @@ module Testcontainers
     def first_mapped_port
       raise ContainerNotStartedError unless @_container
       container_ports.map { |port| mapped_port(port) }.first
+    end
+
+    # Returns the container's mounts.
+    #
+    # @return [Array<Hash>] An array of the container's mounts.
+    # @raise [ConnectionError] If the connection to the Docker daemon fails.
+    # @raise [ContainerNotStartedError] If the container has not been started.
+    def mounts
+      info["Mounts"]
+    end
+
+    # Returns the container's mount names.
+    #
+    # @return [Array<String>] The container's mount names.
+    # @raise [ConnectionError] If the connection to the Docker daemon fails.
+    # @raise [ContainerNotStartedError] If the container has not been started.
+    def mount_names
+      mounts.map { |mount| mount["Name"] }
     end
 
     # Returns the value for the given environment variable.


### PR DESCRIPTION
The `Docker::Container` `remove` method in [docker-api conditionally accepts a hash of options](https://github.com/upserve/docker-api/blob/6f7b7cd2b790ec0ca69f805d72ae0c504c8b2f49/lib/docker/container.rb#L248)

Furthermore, removing a docker container, by default, will [not remove the volumes](https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerDelete) unless you pass `v: true` as a parameter.

Without the ability to pass `v: true` we can end up with many dangling volumes that take up disk space.

This commit adds an optional hash argument to the `DockerContainer` `#remove` method, it defaults to an empty hash.

To assist with tests I've also added:
  - `DockerContainer#mounts` method which returns an array of the mount hashes from the container `#info`
  - `DockerContainer#mount_names` which returns an array of the mount names (ids)
  
  Not changed but perhaps good to discuss: should `remove` also remove the volumes by default?