### PR TITLE
Use Ruby 3.3.0-rc1 to fix mysql_ar_rspec

### DIFF
--- a/.github/workflows/examples-mysql_rspec.yml
+++ b/.github/workflows/examples-mysql_rspec.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.2.0'
+          - '3.3.0-rc1'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
In Ruby < 3.3.0 the default `timeout` gem version is `0.3.1`. `ActiveRecord >= 7.1` requires `timeout >= 0.4.0`. This [causes a problem with inline gemfiles](https://github.com/HeyNonster/testcontainers-ruby/blob/6d966d9638d05b2d372aeee8c17a7a0e7a876285/examples/mysql_ar_rspec.rb#L3) because `rubygems` loads `timeout 0.3.1` then `ActiveRecord` tries to require `timeout 0.4.1,` but timeout is already loaded and we end up with this error:

```
runtime.rb:304:in `check_for_activated_spec!': You have already activated timeout 0.3.1, but your 
Gemfile requires timeout 0.4.1. Since timeout is a default gem, you can either remove your 
dependency on it or try updating to a newer version of bundler that supports timeout as a default 
gem. (Gem::LoadError)
```

Ruby 3.3.0 bumps the [default timeout version to 0.4.0](https://stdgems.org/default_gems.json) though, so we can use Ruby 3.3.0 to fix ci.

Locally, we need to wait for a new `rubygems` version that installs `timeout` to `>= 0.4.0` by default _or_ run `gem install --default timeout -v 0.4.1`.