### PR TITLE
Allow passing options to `Docker::Image.create`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Added
+
+- DockerContainer#new now accepts optional keyword argument `image_create_options` which accepts a hash. Passes the options to `Docker::Image.create`. See the [Docker ImageCreate api](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageCreate) for available parameters.
+
+- DockerContainer#remove now accepts an optional options hash. See the [Docker ContainerDelete api](https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerDelete) for available parameters.
+
 ## [0.1.3] - 2023-06-10
 
 ### Added

--- a/core/lib/testcontainers.rb
+++ b/core/lib/testcontainers.rb
@@ -12,6 +12,8 @@ module Testcontainers
 
   class ConnectionError < Error; end
 
+  class NotFoundError < Error; end
+
   class TimeoutError < Error; end
 
   class ContainerNotStartedError < Error; end

--- a/core/test/docker_container_test.rb
+++ b/core/test/docker_container_test.rb
@@ -30,6 +30,20 @@ class DockerContainerTest < TestcontainersTest
     super
   end
 
+  def test_it_creates_an_image_with_options
+    good_container = Testcontainers::DockerContainer.new("hello-world", image_create_options: {"tag" => "latest"})
+    bad_container = Testcontainers::DockerContainer.new("hello-world", image_create_options: {"tag" => "nonexistent_tag"})
+    good_container.start
+
+    assert good_container.exists?
+    assert_raises(Testcontainers::NotFoundError) { bad_container.start }
+  ensure
+    good_container.stop if good_container.exists? && good_container.running?
+    good_container.remove if good_container.exists?
+    bad_container.stop if bad_container.exists? && bad_container.running?
+    bad_container.remove if bad_container.exists?
+  end
+
   def test_it_returns_the_container_image
     assert_equal "hello-world", @container.image
   end


### PR DESCRIPTION
The [Docker ImageCreate](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageCreate) api accepts a variety of parameters, you can [pass those arguments in a hash](https://github.com/upserve/docker-api/blob/6f7b7cd2b790ec0ca69f805d72ae0c504c8b2f49/lib/docker/image.rb#L119) as the first argument to `Docker:Image.create`

For the `platform` behavior, there is default behavior which is notable:

```
Default: ""

When used in combination with the fromImage option, the daemon checks if the given image is present
in the local image cache with the given OS and Architecture, and otherwise attempts to pull the image. 
If the option is not set, the host's native OS and Architecture are used.
...
```

Because it defauilts to the host's native architecture, it will attempt to pull images matching that architecture and raises not found if an image of that architecture doesn't exist. This can be a problem when, for example, attempting to pull a `mysql` image on Mx Macs. `Testcontainers::DockerContainer.create('mysql:5.7')` will fail because, as of this writing, arm images are not created for `mysql:5.7`.

The solution to this is to pass `platform: 'linux/amd64'` to `Docker::Image.create`. This tells Docker we specifically want a image for that architecture (Rosetta on Mac OS X can run `linux/amd64` images).

This commit adds an optional `image_create_options` kwarg to `DockerContainer#initialize` that defaults to an empty hash. This kwarg allows for us to pass create parameters to `Docker::Image.create`.

I've also added a `NotFoundError` class because it seems that the convention is to wrap dependency errors in a `Textcontainers` error class.

Updates the readme, including a readme addition to explain the changes in #31.