### PR TITLE
Prepare for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Testcontainers
+
+TestContainers is composed of modules for common databases and services. This changelog only notes changes to the collection of modules. See the individual module changelogs for detailed information:
+
+- [DockerContainer (core)](https://github.com/testcontainers/testcontainers-ruby/tree/main/core/CHANGELOG.md)
+
+- [ComposeContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/compose/CHANGELOG.md)
+
+- [ElasticsearchContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/elasticsearch/CHANGELOG.md)
+
+- [MariadbContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/mariadb/CHANGELOG.md)
+
+- [MongoContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/mongo/CHANGELOG.md)
+
+- [MysqlContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/mysql/CHANGELOG.md)
+
+- [NginxContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/nginx/CHANGELOG.md)
+
+- [PostgresContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/postgres/CHANGELOG.md)
+
+- [RabbitmqContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/rabbitmq/CHANGELOG.md)
+
+- [RedisContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/redis/CHANGELOG.md)
+
+- [RedpandaContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/redpanda/CHANGELOG.md)
+
+- [SeleniumContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/selenium/CHANGELOG.md)
+
+## [0.2.0] - 2023-12-18
+
+### Added
+
+- ComposeContainer. See the [testcontainers-compose readme](https://github.com/testcontainers/testcontainers-ruby/tree/main/compose/README.md) for more information.
+- SeleniumContainer. See the [testcontainers-selenium readme](https://github.com/testcontainers/testcontainers-ruby/tree/main/selenium/README.md) for more information.
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,80 +1,80 @@
 PATH
   remote: .
   specs:
-    testcontainers (0.1.3)
-      testcontainers-core (= 0.1.3)
+    testcontainers (0.2.0)
+      testcontainers-core (= 0.2.0)
 
 PATH
   remote: compose
   specs:
     testcontainers-compose (0.1.0)
-      testcontainers-core (~> 0.1.2)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: elasticsearch
   specs:
     testcontainers-elasticsearch (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: mariadb
   specs:
     testcontainers-mariadb (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: mongo
   specs:
     testcontainers-mongo (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: mysql
   specs:
     testcontainers-mysql (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: nginx
   specs:
     testcontainers-nginx (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: postgres
   specs:
     testcontainers-postgres (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: rabbitmq
   specs:
     testcontainers-rabbitmq (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: redis
   specs:
     testcontainers-redis (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: redpanda
   specs:
     testcontainers-redpanda (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 PATH
   remote: selenium
   specs:
     testcontainers-selenium (0.1.0)
-      testcontainers-core (~> 0.1.2)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -174,6 +174,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-darwin-22
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Tescontainers contains modules that can be used instead of the generic
 DockerContainer for common databases and services, providing
 pre-configured setups and reducing the amount of boilerplate code:
 
+- [ComposeContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/compose)
+
 - [ElasticsearchContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/elasticsearch)
 
 - [MariadbContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/mariadb)
@@ -68,6 +70,7 @@ pre-configured setups and reducing the amount of boilerplate code:
 
 - [RedpandaContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/redpanda)
 
+- [SeleniumContainer](https://github.com/testcontainers/testcontainers-ruby/tree/main/selenium)
 
 
 ## Development

--- a/compose/Gemfile.lock
+++ b/compose/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-compose (0.1.0)
-      testcontainers-core (~> 0.1.2)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -65,6 +65,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/compose/testcontainers-compose.gemspec
+++ b/compose/testcontainers-compose.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.2"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/core/Gemfile.lock
+++ b/core/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 GEM
@@ -57,6 +57,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/core/lib/testcontainers/version.rb
+++ b/core/lib/testcontainers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Testcontainers
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/elasticsearch/Gemfile.lock
+++ b/elasticsearch/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-elasticsearch (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -76,6 +76,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   elasticsearch (~> 8.7)

--- a/elasticsearch/testcontainers-elasticsearch.gemspec
+++ b/elasticsearch/testcontainers-elasticsearch.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/mariadb/Gemfile.lock
+++ b/mariadb/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-mariadb (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -64,6 +64,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   minitest (~> 5.0)

--- a/mariadb/testcontainers-mariadb.gemspec
+++ b/mariadb/testcontainers-mariadb.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/module-gen/templates/module.gemspec.tt
+++ b/module-gen/templates/module.gemspec.tt
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.2"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/mongo/Gemfile.lock
+++ b/mongo/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-mongo (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -66,6 +66,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/mongo/testcontainers-mongo.gemspec
+++ b/mongo/testcontainers-mongo.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/mysql/Gemfile.lock
+++ b/mysql/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-mysql (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -64,6 +64,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   minitest (~> 5.0)

--- a/mysql/testcontainers-mysql.gemspec
+++ b/mysql/testcontainers-mysql.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/nginx/Gemfile.lock
+++ b/nginx/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-nginx (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -63,6 +63,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   minitest (~> 5.0)

--- a/nginx/testcontainers-nginx.gemspec
+++ b/nginx/testcontainers-nginx.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/postgres/Gemfile.lock
+++ b/postgres/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-postgres (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -64,6 +64,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/postgres/testcontainers-postgres.gemspec
+++ b/postgres/testcontainers-postgres.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/rabbitmq/Gemfile.lock
+++ b/rabbitmq/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-rabbitmq (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -72,6 +72,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/rabbitmq/testcontainers-rabbitmq.gemspec
+++ b/rabbitmq/testcontainers-rabbitmq.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/redis/Gemfile.lock
+++ b/redis/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-redis (0.1.1)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -68,6 +68,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   minitest (~> 5.0)

--- a/redis/testcontainers-redis.gemspec
+++ b/redis/testcontainers-redis.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/redpanda/Gemfile.lock
+++ b/redpanda/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-redpanda (0.1.0)
-      testcontainers-core (~> 0.1.3)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -69,6 +69,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   minitest (~> 5.0)

--- a/redpanda/testcontainers-redpanda.gemspec
+++ b/redpanda/testcontainers-redpanda.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.3"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/selenium/Gemfile.lock
+++ b/selenium/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: ../core
   specs:
-    testcontainers-core (0.1.3)
+    testcontainers-core (0.2.0)
       docker-api (~> 2.2)
 
 PATH
   remote: .
   specs:
     testcontainers-selenium (0.1.0)
-      testcontainers-core (~> 0.1.2)
+      testcontainers-core (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -70,6 +70,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/selenium/testcontainers-selenium.gemspec
+++ b/selenium/testcontainers-selenium.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "testcontainers-core", "~> 0.1.2"
+  spec.add_dependency "testcontainers-core", "~> 0.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Prepares for a `v0.2.0` release. Notes on that:

- I bumped the `minor` version to `2`. The convention thusfar, however, has been to bump the `patch` version. If bumping the patch version is still preferred I can update the version bump appropriately.
- In doing so, I had to loosen the `testcontainers-core` requirement on the modules to `~> 0.1`.
- Added a top-level `CHANGELOG.md`. That changelog only serves to document when any modules are added/removed. It links to the individual changelogs at the top.

Hope you don't mind me opening a version bump PR. We at Zendesk would like to start using some of the new changes 🙂 ✌️ 