### PR TITLE
Bump module versions to `v0.2.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: compose
   specs:
-    testcontainers-compose (0.1.0)
+    testcontainers-compose (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
@@ -19,61 +19,61 @@ PATH
 PATH
   remote: elasticsearch
   specs:
-    testcontainers-elasticsearch (0.1.0)
+    testcontainers-elasticsearch (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: mariadb
   specs:
-    testcontainers-mariadb (0.1.1)
+    testcontainers-mariadb (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: mongo
   specs:
-    testcontainers-mongo (0.1.0)
+    testcontainers-mongo (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: mysql
   specs:
-    testcontainers-mysql (0.1.1)
+    testcontainers-mysql (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: nginx
   specs:
-    testcontainers-nginx (0.1.0)
+    testcontainers-nginx (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: postgres
   specs:
-    testcontainers-postgres (0.1.1)
+    testcontainers-postgres (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: rabbitmq
   specs:
-    testcontainers-rabbitmq (0.1.0)
+    testcontainers-rabbitmq (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: redis
   specs:
-    testcontainers-redis (0.1.1)
+    testcontainers-redis (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: redpanda
   specs:
-    testcontainers-redpanda (0.1.0)
+    testcontainers-redpanda (0.2.0)
       testcontainers-core (~> 0.1)
 
 PATH
   remote: selenium
   specs:
-    testcontainers-selenium (0.1.0)
+    testcontainers-selenium (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/compose/Gemfile.lock
+++ b/compose/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-compose (0.1.0)
+    testcontainers-compose (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/compose/lib/testcontainers/compose/version.rb
+++ b/compose/lib/testcontainers/compose/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Compose
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/elasticsearch/Gemfile.lock
+++ b/elasticsearch/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-elasticsearch (0.1.0)
+    testcontainers-elasticsearch (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/elasticsearch/lib/testcontainers/elasticsearch/version.rb
+++ b/elasticsearch/lib/testcontainers/elasticsearch/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Elasticsearch
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/mariadb/Gemfile.lock
+++ b/mariadb/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-mariadb (0.1.1)
+    testcontainers-mariadb (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/mariadb/lib/testcontainers/mariadb/version.rb
+++ b/mariadb/lib/testcontainers/mariadb/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Mariadb
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/mongo/Gemfile.lock
+++ b/mongo/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-mongo (0.1.0)
+    testcontainers-mongo (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/mongo/lib/testcontainers/mongo/version.rb
+++ b/mongo/lib/testcontainers/mongo/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Mongo
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/mysql/Gemfile.lock
+++ b/mysql/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-mysql (0.1.1)
+    testcontainers-mysql (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/mysql/lib/testcontainers/mysql/version.rb
+++ b/mysql/lib/testcontainers/mysql/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Mysql
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/nginx/Gemfile.lock
+++ b/nginx/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-nginx (0.1.0)
+    testcontainers-nginx (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/nginx/lib/testcontainers/nginx/version.rb
+++ b/nginx/lib/testcontainers/nginx/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Nginx
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/postgres/Gemfile.lock
+++ b/postgres/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-postgres (0.1.1)
+    testcontainers-postgres (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/postgres/lib/testcontainers/postgres/version.rb
+++ b/postgres/lib/testcontainers/postgres/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Postgres
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/rabbitmq/Gemfile.lock
+++ b/rabbitmq/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-rabbitmq (0.1.0)
+    testcontainers-rabbitmq (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/rabbitmq/lib/testcontainers/rabbitmq/version.rb
+++ b/rabbitmq/lib/testcontainers/rabbitmq/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Rabbitmq
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/redis/Gemfile.lock
+++ b/redis/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-redis (0.1.1)
+    testcontainers-redis (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/redis/lib/testcontainers/redis/version.rb
+++ b/redis/lib/testcontainers/redis/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Redis
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/redpanda/Gemfile.lock
+++ b/redpanda/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-redpanda (0.1.0)
+    testcontainers-redpanda (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/redpanda/lib/testcontainers/redpanda/version.rb
+++ b/redpanda/lib/testcontainers/redpanda/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Redpanda
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/selenium/Gemfile.lock
+++ b/selenium/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    testcontainers-selenium (0.1.0)
+    testcontainers-selenium (0.2.0)
       testcontainers-core (~> 0.1)
 
 GEM

--- a/selenium/lib/testcontainers/selenium/version.rb
+++ b/selenium/lib/testcontainers/selenium/version.rb
@@ -2,6 +2,6 @@
 
 module Testcontainers
   module Selenium
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
We'll need new versions of each module gem in order for them to be able to bundle with `testcontainers v0.2+`.