### PR TITLE
Fix redpanda tests

### DIFF
--- a/redpanda/lib/testcontainers/redpanda.rb
+++ b/redpanda/lib/testcontainers/redpanda.rb
@@ -75,8 +75,8 @@ module Testcontainers
       startup_script = StringIO.new
       startup_script.print("#!/bin/sh\n")
       startup_script.print("/usr/bin/rpk redpanda start --mode dev-container")
-      startup_script.print(" --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092")
-      startup_script.print(" --advertise-kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://#{host}:#{mapped_port(port)}")
+      startup_script.print(" --kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://127.0.0.1:9092")
+      startup_script.print(" --advertise-kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://#{host}:#{mapped_port(port)}")
       startup_script
     end
 

--- a/redpanda/lib/testcontainers/redpanda.rb
+++ b/redpanda/lib/testcontainers/redpanda.rb
@@ -74,8 +74,8 @@ module Testcontainers
     def _startup_script
       startup_script = StringIO.new
       startup_script.print("#!/bin/sh\n")
-      startup_script.print("/usr/bin/rpk redpanda start --mode dev-container")
-      startup_script.print(" --kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://127.0.0.1:9092")
+      startup_script.print("/usr/bin/rpk redpanda start --mode=dev-container --smp=1 --memory=1G")
+      startup_script.print(" --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092")
       startup_script.print(" --advertise-kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://#{host}:#{mapped_port(port)}")
       startup_script
     end


### PR DESCRIPTION
It seems[^1] that `redpanda` will now throw errors if the advertised address is set to `0.0.0.0`.

[^1]: (https://github.com/redpanda-data/redpanda/issues/12395)