### PR TITLE
[Doc ]Fix typo on selenium/README.md

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -33,8 +33,8 @@ require "testcontainers/compose"
 Create a new instance of the `Testcontainers::ComposeContainer` class:
 
 ``` ruby
-compose = Testcontainer::ComposeContainer.new(filepath: Dir.getwd)
-```	
+compose = Testcontainers::ComposeContainer.new(filepath: Dir.getwd)
+```
 
 The instance creates a set of containers defined on the .yml file, the 'compose.start' wakes up all containers as service
 
@@ -52,7 +52,7 @@ compose.stop
 
 ### Connecting to services
 
-Once the service is running, you can obtain the mapped port to connect to it: 
+Once the service is running, you can obtain the mapped port to connect to it:
 
 ```ruby
 compose.service_port(service: "hub", port: 4444)
@@ -85,7 +85,7 @@ You can specify the name of different docker-compose files also:
 
 ```ruby
 compose_filenames = ["docker-compose.dbs.yml", "docker-compose.web.yml"]
-compose = Testcontainer::ComposeContainer.new(filepath: Dir.getwd, compose_filenames: compose_filenames)
+compose = Testcontainers::ComposeContainer.new(filepath: Dir.getwd, compose_filenames: compose_filenames)
 compose.start
 ```
 

--- a/selenium/README.md
+++ b/selenium/README.md
@@ -36,16 +36,16 @@ require "testcontainers/selenium"
 Create a new instance of the `Testcontainers::SeleniumContainer` class:
 
 ```ruby
-container = Testcontainer::SeleniumContainer.new
+container = Testcontainers::SeleniumContainer.new
 ```
 
 This creates a new container with the default Selenium configuration for firefox, the vnc password will be `secret`. You can customise by passing arguments to the constructor:
 
 ```ruby
-container = Testcontainer::SeleniumContainer.new(capabilities: :chrome, vnc_no_password: true)
+container = Testcontainers::SeleniumContainer.new(capabilities: :chrome, vnc_no_password: true)
 ```
 
-### Starting and Stopping a container 
+### Starting and Stopping a container
 
 Start the container
 
@@ -59,7 +59,7 @@ Stop the container when you're done
 container.stop
 ```
 
-### Connecting to the Selenium container 
+### Connecting to the Selenium container
 
 Once the container is running, you can obtain the connection details using the following methods:
 
@@ -85,7 +85,7 @@ There are complete examples of how to use testcontainers-selenium to create cont
 require "testcontainers/selenium"
 require "selenium-webdriver"
 
-container = Testcontainer::SeleniumContainer.new
+container = Testcontainers::SeleniumContainer.new
 container.start
 
 driver = Selenium::WebDriver.for(:firefox, :url => @container.selenium_url)


### PR DESCRIPTION
I'm trying testcontainers-ruby and found typos in some documents.

Note: `core/CHANGELOG.md#65` still contains the typo and I'm unsure I should also fix this or not.

```markdown
- Initial release of the project with the Testcontainer::DockerContainer working.
```