### PR TITLE
fix: bridge_ip method does not exist

### DIFF
--- a/core/lib/testcontainers/docker_container.rb
+++ b/core/lib/testcontainers/docker_container.rb
@@ -700,7 +700,7 @@ module Testcontainers
 
       if inside_container? && ENV["DOCKER_HOST"].nil?
         gateway_ip = container_gateway_ip
-        return bridge_ip if gateway_ip == host
+        return container_bridge_ip if gateway_ip == host
         return gateway_ip
       end
       host


### PR DESCRIPTION
`container_bridge_ip` should be used.

```
NameError:
  undefined local variable or method `bridge_ip' for an instance of Testcontainers::RedisContainer
# /usr/local/bundle/gems/testcontainers-core-0.2.0/lib/testcontainers/docker_container.rb:703:in `host'
```