### PR TITLE
Update MySQL healthcheck query syntax in default options

### DIFF
--- a/mysql/lib/testcontainers/mysql.rb
+++ b/mysql/lib/testcontainers/mysql.rb
@@ -127,7 +127,7 @@ module Testcontainers
     end
 
     def _default_healthcheck_options
-      {test: ["/usr/bin/mysql", "--protocol=TCP", "--port=#{port}", "--user=#{username}", "--password=#{password}", database, "--silent", "--execute=SELECT 1;"], interval: 1, timeout: 5, retries: 5}
+      {test: ["/usr/bin/mysql", "--protocol=TCP", "--port=#{port}", "--user=#{username}", "--password=#{password}", database, "--silent", "--execute=SELECT(1);"], interval: 1, timeout: 5, retries: 5}
     end
   end
 end


### PR DESCRIPTION
Fixes an issue caused by a bug in Podman. Arguments with spaces in healthchecks are incorrectly, which causes MySQL containers with default healthchecks to never become healthy.

See: https://github.com/containers/podman/issues/26519

```shell
podman inspect healthcheck-test-mysql | jq '.[].Config.Healthcheck'
```

```diff
--- healthcheck_bug.json	2025-06-26 12:12:35
+++ healthcheck_fix.json	2025-06-26 12:12:27
@@ -3,7 +3,8 @@
     "CMD",
     "/usr/bin/mysql",
    "--protocol=TCP",
    "--port=3306",
    "--user=xxx",
    "--password=xxx",
    "healthcheck_test",
    "--silent",
-    "--execute=SELECT",
-    "1;"
+    "--execute=SELECT(1);"
   ],
   "Interval": 1000000000,
   "Timeout": 5000000000,
  "Retries": 5
}
```